### PR TITLE
feat: 사용자별 데이터 분리 및 구글 로그인 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "prisma-planner",
       "version": "0.1.0",
       "dependencies": {
+        "@auth/prisma-adapter": "^2.11.1",
         "@hugeicons/core-free-icons": "^4.0.0",
         "@hugeicons/react": "^1.1.5",
         "@prisma/adapter-better-sqlite3": "^7.4.2",
@@ -18,9 +19,11 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
         "next": "16.1.6",
+        "next-auth": "^5.0.0-beta.30",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "react-icons": "^5.6.0",
         "shadcn": "^4.0.2",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
@@ -73,6 +76,47 @@
         "nup": "bin/nup.mjs"
       }
     },
+    "node_modules/@auth/core": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.1.tgz",
+      "integrity": "sha512-t9cJ2zNYAdWMacGRMT6+r4xr1uybIdmYa49calBPeTqwgAFPV/88ac9TEvCR85pvATiSPt8VaNf+Gt24JIT/uw==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@auth/prisma-adapter": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.11.1.tgz",
+      "integrity": "sha512-Ke7DXP0Fy0Mlmjz/ZJLXwQash2UkA4621xCM0rMtEczr1kppLc/njCbUkHkIQ/PnmILjqSPEKeTjDPsYruvkug==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.1"
+      },
+      "peerDependencies": {
+        "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5 || >=6"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -101,7 +145,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -637,7 +680,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1818,7 +1860,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1919,6 +1960,15 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/@prisma/adapter-better-sqlite3": {
       "version": "7.4.2",
@@ -3977,7 +4027,6 @@
       "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3988,7 +4037,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3999,7 +4047,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4061,7 +4108,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4625,7 +4671,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5020,7 +5065,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -5164,7 +5208,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6345,7 +6388,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6531,7 +6573,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7680,7 +7721,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9312,6 +9352,62 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
+      "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.0"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-auth/node_modules/@auth/core": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.0.tgz",
+      "integrity": "sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -9486,6 +9582,15 @@
       "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
+      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -10000,6 +10105,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -10059,7 +10183,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.15.0",
         "@prisma/engines": "6.15.0"
@@ -10345,7 +10468,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10355,12 +10477,20 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {
@@ -11663,7 +11793,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11949,7 +12078,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12523,7 +12651,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@auth/prisma-adapter": "^2.11.1",
     "@hugeicons/core-free-icons": "^4.0.0",
     "@hugeicons/react": "^1.1.5",
     "@prisma/adapter-better-sqlite3": "^7.4.2",
@@ -19,9 +20,11 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
+    "next-auth": "^5.0.0-beta.30",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-icons": "^5.6.0",
     "shadcn": "^4.0.2",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"

--- a/prisma/migrations/20260309210240_add_auth_models/migration.sql
+++ b/prisma/migrations/20260309210240_add_auth_models/migration.sql
@@ -1,0 +1,80 @@
+/*
+  Warnings:
+
+  - Added the required column `userId` to the `Category` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `userId` to the `Todo` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT,
+    "email" TEXT,
+    "emailVerified" DATETIME,
+    "image" TEXT
+);
+
+-- CreateTable
+CREATE TABLE "Account" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerAccountId" TEXT NOT NULL,
+    "refresh_token" TEXT,
+    "access_token" TEXT,
+    "expires_at" INTEGER,
+    "token_type" TEXT,
+    "scope" TEXT,
+    "id_token" TEXT,
+    "session_state" TEXT,
+    CONSTRAINT "Account_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "sessionToken" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expires" DATETIME NOT NULL,
+    CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Category" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "color" TEXT,
+    "userId" TEXT NOT NULL,
+    CONSTRAINT "Category_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Category" ("color", "id", "name") SELECT "color", "id", "name" FROM "Category";
+DROP TABLE "Category";
+ALTER TABLE "new_Category" RENAME TO "Category";
+CREATE UNIQUE INDEX "Category_name_userId_key" ON "Category"("name", "userId");
+CREATE TABLE "new_Todo" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "completed" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "categoryId" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+    CONSTRAINT "Todo_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Todo_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Todo" ("categoryId", "completed", "createdAt", "id", "title") SELECT "categoryId", "completed", "createdAt", "id", "title" FROM "Todo";
+DROP TABLE "Todo";
+ALTER TABLE "new_Todo" RENAME TO "Todo";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Account_provider_providerAccountId_key" ON "Account"("provider", "providerAccountId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Session_sessionToken_key" ON "Session"("sessionToken");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,11 +7,28 @@ datasource db {
   url = env("DATABASE_URL")
 }
 
+model User {
+  id String @id @default(cuid())
+  name String?
+  email String? @unique
+  emailVerified DateTime?
+  image String?
+  accounts Account[]
+  sessions Session[]
+
+  categories Category[]
+  todos Todo[]
+}
+
 model Category {
   id Int @id @default(autoincrement())
-  name String @unique
+  name String 
   color String?
+  userId String
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
   todos Todo[]
+
+  @@unique([name, userId])
 }
 
 model Todo {
@@ -20,5 +37,33 @@ model Todo {
   completed Boolean @default(false)
   createdAt DateTime @default(now())
   categoryId Int
-  category Category @relation(fields: [categoryId], references: [id])
+  category Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  userId String
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model Account {
+  id String @id @default(cuid())
+  userId String
+  type String
+  provider String
+  providerAccountId String
+  refresh_token String? 
+  access_token String? 
+  expires_at Int?
+  token_type String?
+  scope String?
+  id_token String? 
+  session_state String?
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id String @id @default(cuid())
+  sessionToken String @unique
+  userId String
+  expires DateTime
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }

--- a/src/app/_components/AuthSession.tsx
+++ b/src/app/_components/AuthSession.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export default function AuthSession({ children }: { children: React.ReactNode }) {
+  return (
+    <SessionProvider>
+      {children}
+    </SessionProvider>
+  );
+}

--- a/src/app/_components/AuthSession.tsx
+++ b/src/app/_components/AuthSession.tsx
@@ -1,11 +1,27 @@
 "use client";
 
-import { SessionProvider } from "next-auth/react";
+import { SessionProvider, useSession } from "next-auth/react";
+import LoadingSpinner from "./LoadingSpinner";
+
+function SessionGuard({ children }: { children: React.ReactNode }) {
+  const { status } = useSession();
+  
+  // 세션 확인 중일 때 로딩 스피너 표시
+  if (status === "loading") {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <LoadingSpinner size="md" />
+      </div>
+    );
+  }
+
+  return <>{children}</>
+}
 
 export default function AuthSession({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider>
-      {children}
+      <SessionGuard>{children}</SessionGuard>
     </SessionProvider>
   );
 }

--- a/src/app/_components/CategorySidebar.tsx
+++ b/src/app/_components/CategorySidebar.tsx
@@ -5,10 +5,11 @@ import { axiosApi } from "../_lib/axios";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
-import { Menu } from "lucide-react";
+import { Menu, LogOut } from "lucide-react"; 
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Category } from "@/model/Category";
 import AddCategoryDialog from "./AddCategoryDialog";
+import { signOut, useSession } from "next-auth/react"; 
 
 type Props = {
   onSelectCategory: (id: number | null, name: string) => void;
@@ -17,6 +18,7 @@ type Props = {
 
 export default function CategorySidebar({ onSelectCategory, selectedId }: Props) {
   const [categories, setCategories] = useState<Category[]>([]);
+  const { data: session } = useSession(); 
 
   const fetchCategories = useCallback(async () => {
     try {
@@ -31,9 +33,9 @@ export default function CategorySidebar({ onSelectCategory, selectedId }: Props)
     fetchCategories();
   }, [fetchCategories]);
 
-  // 사이드바 내부 콘텐츠
   const SidebarContent = () => (
     <div className="flex flex-col h-full py-4">
+      {/* 헤더 영역 */}
       <div className="px-4 mb-4 flex items-center justify-between">
         <button 
           onClick={() => onSelectCategory(null, "전체 목록")}
@@ -41,14 +43,16 @@ export default function CategorySidebar({ onSelectCategory, selectedId }: Props)
         >
           Planner
         </button>
-        <AddCategoryDialog onSuccess={fetchCategories} />
+        <div className="lg:mr-0 mr-10">
+          <AddCategoryDialog onSuccess={fetchCategories} />
+        </div>
       </div>
       
       <Separator className="mb-4" />
 
+      {/* 카테고리 리스트 영역 */}
       <ScrollArea className="flex-1 px-2">
         <div className="space-y-1">
-          {/* 전체보기 버튼 추가 */}
           <Button
             variant={selectedId === null ? "secondary" : "ghost"}
             className="w-full justify-start font-normal"
@@ -74,12 +78,42 @@ export default function CategorySidebar({ onSelectCategory, selectedId }: Props)
           ))}
         </div>
       </ScrollArea>
+
+      {/* 하단 프로필 영역 */}
+      <div className="mt-auto px-4 pt-4 border-t">
+        <div className="flex items-center justify-between group">
+          <div className="flex items-center gap-3">
+            {/* 프로필 이미지 */}
+            {session?.user?.image ? (
+              <img 
+                src={session.user.image} 
+                alt="profile" 
+                className="w-8 h-8 rounded-full"
+              />
+            ) : (
+              <div className="w-8 h-8 rounded-full bg-slate-200" />
+            )}
+            <span className="text-sm font-medium text-slate-700 truncate max-w-[100px]">
+              {session?.user?.name || "사용자"}
+            </span>
+          </div>
+          
+          {/* 로그아웃 버튼 */}
+          <Button 
+            variant="ghost" 
+            size="icon" 
+            className="text-slate-500 hover:text-red-500 hover:bg-red-50"
+            onClick={() => signOut({ callbackUrl: "/" })}
+          >
+            <LogOut className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
     </div>
   );
 
   return (
     <>
-      {/* 모바일용 시트 (Lg 사이즈 미만에서만 보임) */}
       <div className="lg:hidden fixed top-6 left-6 z-50">
         <Sheet>
           <SheetTrigger asChild>
@@ -93,7 +127,6 @@ export default function CategorySidebar({ onSelectCategory, selectedId }: Props)
         </Sheet>
       </div>
 
-      {/* 데스크톱용 고정 사이드바 (Lg 사이즈 이상에서만 보임) */}
       <aside className="hidden lg:flex w-64 border-r bg-muted/20 flex-col h-screen sticky top-0">
         <SidebarContent />
       </aside>

--- a/src/app/_components/LoadingSpinner.tsx
+++ b/src/app/_components/LoadingSpinner.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+type Size = 'xs' | 'sm' | 'md' | 'lg';
+
+type Props = {
+  size: Size;
+}
+
+export default function LoadingSpinner({size}: Props) {
+  const sizeClasses: Record<Size, string> = {
+    xs: 'w-6 h-6',
+    sm: 'w-8 h-8',
+    md: 'w-12 h-12',
+    lg: 'w-16 h-16'
+  };
+
+  return (
+    <div className="flex items-center justify-center">
+      <div 
+        className={`${sizeClasses[size]} border-4 border-gray-200 rounded-full animate-spin`}
+        style={{ borderRightColor: 'transparent' }}
+      />
+    </div>
+  );
+};

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,2 @@
+import { handlers } from "@/auth"
+export const { GET, POST } = handlers

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,17 +1,18 @@
 import { NextResponse } from 'next/server';
 import prisma from '../../../../lib/prisma';
-
-// 모든 카테고리를 가져오는 내부 함수
-async function getCategories() {
-  return await prisma.category.findMany({
-    orderBy: { name: 'asc' }, // 이름순 정렬
-  });
-}
+import { auth } from '@/auth';
 
 // GET: 카테고리 목록 조회
 export async function GET() {
   try {
-    const categories = await getCategories();
+    const session = await auth();
+    if (!session?.user?.id) 
+      return NextResponse.json({ error: '인증 필요'}, { status: 401 });
+
+    const categories = await prisma.category.findMany({
+      where: { userId: session.user.id }, // 본인 것만 필터링
+      orderBy: { name: 'asc' }, // 이름순 정렬
+    });
     return NextResponse.json(categories);
   } catch (error) {
     console.error("원인 파악 용 에러 로그: ", error);
@@ -22,14 +23,21 @@ export async function GET() {
 // POST: 새 카테고리 생성
 export async function POST(request: Request) {
   try {
-    const { name, color } = await request.json();
+    const session = await auth();
+    if (!session?.user?.id) 
+      return NextResponse.json({ error: '인증 필요'}, { status: 401 });
 
+    const { name, color } = await request.json();
     if (!name) {
       return NextResponse.json({ error: '이름은 필수입니다.' }, { status: 400 });
     }
 
     const newCategory = await prisma.category.create({
-      data: { name, color },
+      data: { 
+        name, 
+        color,
+        userId: session.user.id,
+      },
     });
 
     return NextResponse.json(newCategory, { status: 201 });

--- a/src/app/api/todos/[id]/route.ts
+++ b/src/app/api/todos/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import prisma from '../../../../../lib/prisma';
+import { auth } from '@/auth';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -8,11 +9,18 @@ interface RouteParams {
 // PATCH: 할 일 완료 토글
 export async function PATCH(request: Request, { params }: RouteParams) {
   try {
+    const session = await auth();
+    if (!session?.user?.id) 
+      return NextResponse.json({ error: '인증 필요'}, { status: 401 });
+
     const { id } = await params;
     const { completed } = await request.json();
 
     const updatedTodo = await prisma.todo.update({
-      where: { id: Number(id) }, 
+      where: { 
+        id: Number(id),
+        userId: session.user.id, 
+      }, 
       data: { completed },
     });
 
@@ -26,10 +34,17 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 // DELETE: 할 일 삭제
 export async function DELETE(_request: Request, { params }: RouteParams) {
   try {
+    const session = await auth();
+    if (!session?.user?.id) 
+      return NextResponse.json({ error: '인증 필요'}, { status: 401 });
+
     const { id } = await params;
 
     await prisma.todo.delete({
-      where: { id: Number(id) },
+      where: { 
+        id: Number(id),
+        userId: session.user.id, 
+      },
     });
     return NextResponse.json({ message: "삭제되었습니다." }, { status: 200 });
   } catch (error) {

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -1,18 +1,24 @@
 import { NextResponse } from "next/server";
 import prisma from '../../../../lib/prisma';
+import { auth } from "@/auth";
 
 // GET: 할 일 목록 조회
 export async function GET(request: Request) {
   try {
+    const session = await auth();
+    if (!session?.user?.id) 
+      return NextResponse.json({ error: '인증 필요'}, { status: 401 });
+
     const { searchParams } = new URL(request.url);
     const categoryId = searchParams.get("categoryId");
 
-    const whereCondition = categoryId
-      ? { categoryId: Number(categoryId) }
-      : {}; // categoryId가 없으면 전체 조회
+    // 조건문에 userId를 무조건 포함
+    const whereCondition: any = { userId: session.user.id };
+    if (categoryId) 
+      whereCondition.categoryId = Number(categoryId);
 
     const todos = await prisma.todo.findMany({
-      where: whereCondition,
+      where: whereCondition, // userId와 categoryId 둘 다 만족시키는 것만 필터링
       include: { category: true },
       orderBy: { id: "desc" },
     });
@@ -27,8 +33,11 @@ export async function GET(request: Request) {
 // POST: 새 할 일 생성
 export async function POST(request: Request) {
   try {
-    const { title, categoryId } = await request.json();
+    const session = await auth();
+    if (!session?.user?.id) 
+      return NextResponse.json({ error: '인증 필요'}, { status: 401 });
 
+    const { title, categoryId } = await request.json();
     if (!title || !categoryId) {
       return NextResponse.json({ error: "제목과 카테고리 ID가 필요합니다." }, { status: 400 });
     }
@@ -36,10 +45,9 @@ export async function POST(request: Request) {
     const newTodo = await prisma.todo.create({
       data: {
         title,
+        userId: session.user.id,
         // connect를 사용하여 기존 카테고리와 연결
-        category: {
-          connect: { id: Number(categoryId) },
-        },
+        categoryId: Number(categoryId)
       },
       include: {
         category: true, // 생성된 데이터와 함께 부모 카테고리 정보도 반환

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono, Figtree } from "next/font/google";
 import "./globals.css";
 import { cn } from "@/lib/utils";
+import AuthSession from "./_components/AuthSession";
 
 const figtree = Figtree({subsets:['latin'],variable:'--font-sans'});
 
@@ -30,7 +31,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <AuthSession>
+          {children}
+        </AuthSession>
       </body>
     </html>
   );

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,18 @@
+import LoadingSpinner from "./_components/LoadingSpinner"; 
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen w-full flex flex-col items-center justify-center bg-slate-50/50 backdrop-blur-sm fixed inset-0 z-[9999]">
+      <div className="space-y-4 text-center">
+        <LoadingSpinner size="lg" />
+        
+        <div className="space-y-1">
+          <p className="text-lg font-semibold text-slate-700 animate-pulse">
+            플래너를 불러오고 있어요
+          </p>
+          <p className="text-sm text-slate-500">잠시만 기다려주세요...</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import CategorySidebar from "../../app/_components/CategorySidebar";
+import { TodoList } from "../../app/_components/TodoList";
+
+export default function Home() {
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
+  const [selectedCategoryName, setSelectedCategoryName] = useState<string>("전체 목록");
+
+  const handleSelectCategory = (id: number | null, name: string) => {
+    setSelectedCategoryId(id);
+    setSelectedCategoryName(name);
+  };
+
+  return (
+    <div className="flex min-h-screen">
+      {/* 사이드바에 선택 핸들러 전달 */}
+      <CategorySidebar 
+        onSelectCategory={handleSelectCategory} 
+        selectedId={selectedCategoryId} 
+      />
+
+      <main className="flex-1 p-6 lg:p-10">
+        <div className="max-w-4xl mx-auto">
+          <header className="mb-8 ml-10">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground">
+              {selectedCategoryName}
+            </h1>
+          </header>
+
+          {/* 할 일 목록 컴포넌트 */}
+          <TodoList categoryId={selectedCategoryId} />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,38 +1,54 @@
-"use client";
+import { auth, signIn } from "@/auth";
+import { redirect } from "next/navigation";
+import { FcGoogle } from "react-icons/fc";
 
-import { useState } from "react";
-import CategorySidebar from "../app/_components/CategorySidebar";
-import { TodoList } from "../app/_components/TodoList";
+export default async function LoginPage() {
+  const session = await auth();
 
-export default function Home() {
-  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
-  const [selectedCategoryName, setSelectedCategoryName] = useState<string>("전체 목록");
-
-  const handleSelectCategory = (id: number | null, name: string) => {
-    setSelectedCategoryId(id);
-    setSelectedCategoryName(name);
-  };
+  if (session) {
+    redirect("/main");
+  }
 
   return (
-    <div className="flex min-h-screen">
-      {/* 사이드바에 선택 핸들러 전달 */}
-      <CategorySidebar 
-        onSelectCategory={handleSelectCategory} 
-        selectedId={selectedCategoryId} 
-      />
-
-      <main className="flex-1 p-6 lg:p-10">
-        <div className="max-w-4xl mx-auto">
-          <header className="mb-8">
-            <h1 className="text-3xl font-bold tracking-tight text-foreground">
-              {selectedCategoryName}
-            </h1>
-          </header>
-
-          {/* 할 일 목록 컴포넌트 */}
-          <TodoList categoryId={selectedCategoryId} />
+    <main className="min-h-screen flex flex-col items-center justify-center bg-slate-50 px-4">
+      <div className="w-full max-w-md space-y-12 text-center">
+        {/* 로고 영역 */}
+        <div className="space-y-2">
+          <h1 className="text-6xl md:text-8xl font-black tracking-tighter text-slate-900 leading-none">
+            Prisma
+            <br />
+            <span className="text-blue-600">Planner</span>
+          </h1>
+          <p className="text-slate-500 text-lg md:text-xl font-medium">
+            효율적인 카테고리 기반 할 일 관리
+          </p>
         </div>
-      </main>
-    </div>
+
+        {/* 로그인 버튼 영역 */}
+        <div className="flex justify-center">
+          <form
+            action={async () => {
+              "use server";
+              await signIn("google", { redirectTo: "/main" });
+            }}
+          >
+            <button
+              type="submit"
+              className="flex items-center gap-3 px-8 py-4 bg-white border border-slate-200 rounded-2xl shadow-sm hover:shadow-md hover:bg-slate-50 transition-all duration-200 group"
+            >
+              <FcGoogle className="text-2xl group-hover:scale-110 transition-transform" />
+              <span className="text-slate-700 font-semibold text-lg">
+                Google로 시작하기
+              </span>
+            </button>
+          </form>
+        </div>
+      </div>
+
+      {/* 하단 장식용 (선택 사항) */}
+      <footer className="absolute bottom-8 text-slate-400 text-sm">
+        © 2026 Prisma Planner. All rights reserved.
+      </footer>
+    </main>
   );
 }

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,0 +1,33 @@
+import type { NextAuthConfig } from "next-auth";
+import Google from "next-auth/providers/google";
+
+export const authConfig = {
+  providers: [
+    Google({
+      clientId: process.env.AUTH_GOOGLE_ID,
+      clientSecret: process.env.AUTH_GOOGLE_SECRET,
+    }),
+  ],
+
+  callbacks: {
+    authorized({ auth, request: { nextUrl } }) {
+      const isLoggedIn = !!auth?.user;
+      const isOnMainPage = nextUrl.pathname.startsWith("/main");
+
+      if (isOnMainPage) {
+        return isLoggedIn;
+      }
+
+      // 로그인 상태에서 로그인 페이지 접근
+      if (isLoggedIn && nextUrl.pathname === "/") {
+        return Response.redirect(new URL("/main", nextUrl));
+      }
+
+      return true;
+    },
+  },
+
+  pages: {
+    signIn: "/",
+  },
+} satisfies NextAuthConfig;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,22 @@
+import NextAuth from "next-auth"
+import Google from "next-auth/providers/google"
+import { PrismaAdapter } from "@auth/prisma-adapter"
+import prisma from "../lib/prisma"
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  adapter: PrismaAdapter(prisma), 
+  providers: [
+    Google({
+      clientId: process.env.AUTH_GOOGLE_ID,
+      clientSecret: process.env.AUTH_GOOGLE_SECRET,
+    }),
+  ],
+  callbacks: {
+    async session({ session, user }) {
+      if (session.user) {
+        session.user.id = user.id;
+      }
+      return session;
+    },
+  },
+})

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,22 +1,22 @@
-import NextAuth from "next-auth"
-import Google from "next-auth/providers/google"
-import { PrismaAdapter } from "@auth/prisma-adapter"
-import prisma from "../lib/prisma"
+import NextAuth from "next-auth";
+import { PrismaAdapter } from "@auth/prisma-adapter";
+import prisma from "../lib/prisma";
+import { authConfig } from "./auth.config";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
-  adapter: PrismaAdapter(prisma), 
-  providers: [
-    Google({
-      clientId: process.env.AUTH_GOOGLE_ID,
-      clientSecret: process.env.AUTH_GOOGLE_SECRET,
-    }),
-  ],
+  adapter: PrismaAdapter(prisma),
+  session: { strategy: "jwt" },
+
+  ...authConfig,
+
   callbacks: {
-    async session({ session, user }) {
-      if (session.user) {
-        session.user.id = user.id;
+    ...authConfig.callbacks,
+
+    async session({ session, token }) {
+      if (session.user && token.sub) {
+        session.user.id = token.sub;
       }
       return session;
     },
   },
-})
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,5 @@
+export { auth as middleware } from "./auth";
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
## 📌 Related Issue
<!-- #1 — PR 예시 -->
#9 — **사용자별 데이터 분리 및 구글 로그인 연동**

## 🚀 Description
사용자별로 독립적인 플래너 데이터를 관리할 수 있도록하기 위해  
구글 인증 시스템 구축 및 DB 스키마에 User 테이블 추가 및 수정 작업을 진행  

### 1. 인증 시스템(Auth.js)
- **Google OAuth 2.0 연동**: Google Cloud Console을 통해 인증 환경을 구축
- **설정 분리**: Edge Runtime 호환성을 위해 auth.config.ts와 auth.ts를 분리하여 미들웨어 성능을 최적화
- **보안 미들웨어**: 로그인하지 않은 사용자의 `/main` 접근을 차단하고, 로그인된 사용자의 `/` 접근 시 `/main`으로 자동 리다이렉트 처리 로직을 구현

### 2. DB 및 백엔드 로직 수정
- **Prisma 스키마 확장**: `User`, `Account`, `Session` 모델을 추가하고 기존 `Category`, `Todo` 모델과 1:N 관계를 설정
- **데이터 격리**: 모든 API(`GET`, `POST`, `PATCH`, `DELETE`)에서 `session.user.id`를 검증하여, 타 사용자의 데이터에 접근하거나 수정할 수 없도록 보안 필터링을 적용
- **Cascade 삭제**: 사용자가 삭제될 때 관련 카테고리와 할 일 데이터가 함께 정리되도록 설정  

### 3. UI/UX 개선
- **로그인 페이지**: 프로젝트 이름과 구글 로그인 버튼이 포함된 진입 페이지를 구현
- **로딩 처리**: `loading.tsx` 를 활용해 페이지 전환 및 세션 확인 중 중앙 로딩 스피너(`LoadingSpinner`)를 노출하여 UX를 개선
- **사이드바 프로필**: 하단에 현재 로그인한 유저의 정보(이름, 사진)와 로그아웃 기능을 추가
- **모바일 대응**: 모바일 환경에서 카테고리 추가 버튼과 닫기 버튼이 겹치는 UX 이슈를 해결

## 📸 Screenshot
- **로그인 페이지**
<img width="1919" height="903" alt="image" src="https://github.com/user-attachments/assets/b30da736-c1f8-4f92-91f3-6f4cb038fcd5" />  

<br/>

- **사이드바 하단 유저 프로필 및 로그아웃 버튼**  
<img width="252" height="98" alt="image" src="https://github.com/user-attachments/assets/2723bfed-763c-4acd-b3b8-e5ae159b8123" />

## 📢 Notes
- 개발 환경에서 Hot Reload 시 DB 커넥션 과부화를 막기 위해 기존에 구축한 싱글톤 `prisma` 인스턴스를 `auth.ts` 어댑터에 연동  
- 미들웨어에서의 효율적인 인증 확인을 위해 세션 전략을 `jwt`로 설정  
- 배포 시 `.env` 파일에 구글 클라이언트 ID 및 Secret, `AUTH_SECRET` 설정이 필수  